### PR TITLE
Add lmgrep utility

### DIFF
--- a/_data/packages/lmgrep.yaml
+++ b/_data/packages/lmgrep.yaml
@@ -1,0 +1,12 @@
+name: lmgrep
+category: utilities
+description: "Grep-like utility based on Lucene Monitor compiled with GraalVM native-image "
+pros:
+  - Support Lucene query syntax
+  - Single binary CLI utility
+  - Fast startup thanks to GraalVM native-image compiler
+cons:
+  - Early release
+url: https://github.com/dainiusjocas/lucene-grep
+package:
+  install: cluster

--- a/packages/lmgrep.md
+++ b/packages/lmgrep.md
@@ -1,0 +1,4 @@
+---
+layout: package
+package_name: lmgrep
+---


### PR DESCRIPTION
`lmgrep` is a grep-like CLI tool that allows searching through text files using the Lucene query syntax and with multilingual text analysis.

- `lmgrep` is backed by Lucene;
- `lmgrep` starts-up fast thanks to GraalVM native-image compiler;
- `lmgrep` supports Linux, MacOS, and WIndows.

