### PR TITLE
[DOCS] - Update jekyll Docker image to `jekyll/jekyll:4.2.2` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ up a local Jekyll instance and point your browser to [localhost:4000](http://loc
 docker run --rm \
      --volume="$PWD:/srv/jekyll" \
      -p "4000:4000" \
-     -it jekyll/jekyll:3.8 \
+     -it jekyll/jekyll:4.2.2 \
      jekyll serve --watch
 ```
 


### PR DESCRIPTION
#### 📌 Fixes #48

This PR updates the Docker command in the `README.md` to use a newer Jekyll image:

```diff
-     -it jekyll/jekyll:3.8 \
+     -it jekyll/jekyll:4.2.2 \
```

---

We may also need to update [`build.sh` line 337](https://github.com/solr-cool/solr-cool.github.io/blob/147e9a6c47ec24973ec3a0e4a2b3cad637004072/build.sh#L337):

```diff
- docker run --rm --volume="$PWD:/srv/jekyll" -it jekyll/builder:3.8 jekyll build
+ docker run --rm --volume="$PWD:/srv/jekyll" -it jekyll/builder:4.2.2 jekyll build
```

Should we upgrade the `jekyll/builder` version here as well, to stay consistent with the rest of the setup?