### PR TITLE
Add 'Apache Solr Setup GitHub Action' package metadata and project page

### DIFF
--- a/_data/packages/setup-solr-action.yaml
+++ b/_data/packages/setup-solr-action.yaml
@@ -1,0 +1,12 @@
+name: Apache Solr Setup GitHub Action
+category: utilities
+description: "A GitHub Action that automates setup of Apache Solr for CI/CD pipelines, enabling quick and consistent Solr environments for testing and deployment."
+pros:
+  - Easy to integrate in GitHub Actions workflows
+  - Automates Solr setup for CI/CD pipelines
+cons:
+  - Currently limited to GitHub Actions environments
+installation: GitHub Actions Marketplace
+url: https://github.com/DhavalGojiya/setup-solr-action
+license: MIT License
+license_url: https://opensource.org/licenses/MIT

--- a/packages/setup-solr-action.md
+++ b/packages/setup-solr-action.md
@@ -1,0 +1,4 @@
+---
+layout: package
+package_name: setup-solr-action
+---


### PR DESCRIPTION
CC: @epugh 

## Overview

This PR adds a new utility to the Solr-Cool site: **Apache Solr Setup GitHub Action**.  

The action automates the setup of Apache Solr infrastructure in CI/CD pipelines, allowing developers to quickly spin up Solr instances for testing, development, or deployment without manual installation. It ensures consistent environments across pipelines and saves time in continuous integration workflows.

---

## Changes

- Added `_data/packages/setup-solr-action.yaml` with package metadata
- Added `packages/setup-solr-action.md` for the project page

---

## Preview

Here’s how the project card/page will look on the site after merging this PR:

![Apache Solr Setup GitHub Action preview](https://github.com/user-attachments/assets/e93bd3b5-e263-4820-a9c3-9b2ddf12ae22)